### PR TITLE
Adds Generation And Stat Features to Type And Egg Group Page

### DIFF
--- a/pokedex-react-flask-app/src/api/queries/pokeapi.js
+++ b/pokedex-react-flask-app/src/api/queries/pokeapi.js
@@ -811,6 +811,13 @@ const GET_TYPE_INFO = gql`
               id
             }
           }
+          stats: pokemon_v2_pokemonstats {
+            base_stat
+            pokemon_v2_stat {
+              name
+              id
+            }
+          }
         }
       }
     }
@@ -839,6 +846,13 @@ const GET_EGG_GROUP_INFO = gql`
             types: pokemon_v2_pokemontypes {
               type_id
               pokemon_v2_type {
+                name
+                id
+              }
+            }
+            stats: pokemon_v2_pokemonstats {
+              base_stat
+              pokemon_v2_stat {
                 name
                 id
               }

--- a/pokedex-react-flask-app/src/api/queries/pokeapi.js
+++ b/pokedex-react-flask-app/src/api/queries/pokeapi.js
@@ -777,6 +777,7 @@ const GET_TYPE_INFO = gql`
     pokemon_v2_type(where: { id: { _eq: $id } }) {
       name
       id
+      generation_id
       moves: pokemon_v2_moves(where: { name: { _nregex: "(--special)" } }) {
         id
         name
@@ -798,6 +799,11 @@ const GET_TYPE_INFO = gql`
           name
           id
           pokemon_species_id
+          pokemon_v2_pokemonforms {
+            pokemon_v2_versiongroup {
+              generation_id
+            }
+          }
           types: pokemon_v2_pokemontypes {
             type_id
             pokemon_v2_type {
@@ -821,6 +827,7 @@ const GET_EGG_GROUP_INFO = gql`
         pokemon_v2_pokemonspecy {
           name
           id
+          generation_id
           egg_groups: pokemon_v2_pokemonegggroups {
             pokemon_v2_egggroup {
               name

--- a/pokedex-react-flask-app/src/components/Abilities/Abilities.scss
+++ b/pokedex-react-flask-app/src/components/Abilities/Abilities.scss
@@ -1,10 +1,14 @@
 .app__abilities {
-    margin-bottom: 2em;
+  margin-bottom: 2em;
+
+  h4 {
+    margin-bottom: 0;
+  }
 }
 
 .abilities-list {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+  display: flex;
+  flex-direction: column;
   padding-left: 0;
 
   li {

--- a/pokedex-react-flask-app/src/components/EggGroupPokemon/EggGroupPokemon.jsx
+++ b/pokedex-react-flask-app/src/components/EggGroupPokemon/EggGroupPokemon.jsx
@@ -24,6 +24,7 @@ const EggGroupPokemon = ({
   onlySelectedGen,
 }) => {
   const [byEggGroup, setbyEggGroup] = useState();
+  const [tableExtended, setTableExtended] = useState(false);
 
   const eggGroupBarRefs = useRef(null);
   const secondaryEggGroupTableRefsList = useRef([]);
@@ -73,6 +74,8 @@ const EggGroupPokemon = ({
       SpriteComponent,
       NameComponent: PokemonNameComponent,
       TypesImageComponent,
+      hasGeneration: !onlySelectedGen,
+      hasStats: tableExtended,
     });
 
   const modifiedSemiData = Object.values(semi).map((group) => {
@@ -85,6 +88,8 @@ const EggGroupPokemon = ({
         TypesImageComponent,
         pageId: eggGroupId,
         hasEggGroup: true,
+        hasGeneration: !onlySelectedGen,
+        hasStats: tableExtended,
       }),
       name: group.egg_group_name,
     };
@@ -95,6 +100,18 @@ const EggGroupPokemon = ({
     (byEggGroup && Object.keys(semi).length > 0);
   return (
     <div>
+      <div className="checkbox-input">
+        <label htmlFor="ExtendTable">
+          Show Stats
+          <input
+            id="ExtendTable"
+            type="checkbox"
+            className="clickable"
+            checked={tableExtended}
+            onChange={(e) => setTableExtended(e.target.checked)}
+          />
+        </label>
+      </div>
       <h4 className="pure-pokemon-table-header">
         Pure {formatName(name)} Pokemon
       </h4>

--- a/pokedex-react-flask-app/src/components/EggGroupPokemon/EggGroupPokemon.jsx
+++ b/pokedex-react-flask-app/src/components/EggGroupPokemon/EggGroupPokemon.jsx
@@ -16,7 +16,13 @@ import {
 
 import "./EggGroupPokemon.scss";
 
-const EggGroupPokemon = ({ name, list, eggGroupId }) => {
+const EggGroupPokemon = ({
+  name,
+  list,
+  eggGroupId,
+  generationId,
+  onlySelectedGen,
+}) => {
   const [byEggGroup, setbyEggGroup] = useState();
 
   const eggGroupBarRefs = useRef(null);
@@ -28,10 +34,24 @@ const EggGroupPokemon = ({ name, list, eggGroupId }) => {
     setbyEggGroup(false);
   }, [eggGroupId]);
 
+  const filteredPokemon = useMemo(() => {
+    if (generationId === "All") return list;
+    return list.filter((pokemon) => {
+      const gen = pokemon.pokemon_v2_pokemonspecy.generation_id;
+      const isWithinGen = gen <= generationId;
+      const isExactGen = gen === generationId;
+      return onlySelectedGen ? isExactGen : isWithinGen;
+    });
+  }, [list, generationId, onlySelectedGen]);
+
   const sortedPokemonData = useMemo(
     () =>
-      sortPokemonByEggGroups({ pokemons: list, id: eggGroupId, byEggGroup }),
-    [list, byEggGroup]
+      sortPokemonByEggGroups({
+        pokemons: filteredPokemon,
+        id: eggGroupId,
+        byEggGroup,
+      }),
+    [filteredPokemon, byEggGroup]
   );
   const { 0: pure, ...semi } = sortedPokemonData;
 

--- a/pokedex-react-flask-app/src/components/EggGroupPokemon/EggGroupPokemon.scss
+++ b/pokedex-react-flask-app/src/components/EggGroupPokemon/EggGroupPokemon.scss
@@ -59,3 +59,7 @@
 .secondary-egg-group-table {
   scroll-margin-top: 50px;
 }
+
+.checkbox-input {
+  margin-bottom: 1em;
+}

--- a/pokedex-react-flask-app/src/components/PokemonCry/PokemonCry.jsx
+++ b/pokedex-react-flask-app/src/components/PokemonCry/PokemonCry.jsx
@@ -8,10 +8,12 @@ import "./PokemonCry.scss";
 
 const PokemonCry = ({ id }) => {
   const [isPlaying, setIsPlaying] = useState(false);
-  
+  const userAgent = window.navigator.userAgent.toLowerCase();
+  const isIOS = /iphone|ipad|ipod/.test(userAgent);
+
   useEffect(() => {
-    setIsPlaying(false)
-  }, [id])
+    setIsPlaying(false);
+  }, [id]);
 
   const audioRef = useRef(null);
   const audioFile = getCry(id);
@@ -23,7 +25,7 @@ const PokemonCry = ({ id }) => {
     setIsPlaying(true);
   };
 
-  return (
+  return !isIOS ? (
     <div className="pokemon-cry-container">
       <button onClick={togglePlay}>
         Cry{isPlaying && <FiMusic className="music-note" />}
@@ -33,6 +35,8 @@ const PokemonCry = ({ id }) => {
         Your browser does not support the audio element.
       </audio>
     </div>
+  ) : (
+    <></>
   );
 };
 

--- a/pokedex-react-flask-app/src/components/PokemonNav/PokemonNav.jsx
+++ b/pokedex-react-flask-app/src/components/PokemonNav/PokemonNav.jsx
@@ -1,0 +1,62 @@
+import React, { useRef, useEffect } from "react";
+import { Link } from "react-router-dom";
+
+import { HiOutlineChevronLeft, HiOutlineChevronRight } from "react-icons/hi";
+
+import { formatName } from "../../helpers/format";
+import { getSprite } from "../../helpers/pictures";
+
+import "./PokemonNav.scss";
+
+const PokemonNav = ({ id, name }) => {
+  const prevPokemonRef = useRef(null);
+  const nextPokemonRef = useRef(null);
+
+  useEffect(() => {
+    if (id !== 1) {
+      prevPokemonRef.current.style.visibility = "visible";
+    }
+    nextPokemonRef.current.style.visibility = "visible";
+  }, [id]);
+
+  const prevPokemonKey = id - 1;
+  const nextPokemonKey = id + 1;
+
+  function pokemonDoesNotExist(ref) {
+    ref.current.style.visibility = "hidden";
+  }
+
+  return (
+    <div className="pokemon-headers">
+      <div
+        key={prevPokemonKey}
+        ref={prevPokemonRef}
+        className={`pokemon-nav-option ${id <= 1 ? "hide" : ""}`}
+      >
+        <Link to={`/pokemon/${id - 1}`}>
+          <HiOutlineChevronLeft />
+          <img
+            onError={() => pokemonDoesNotExist(prevPokemonRef)}
+            src={getSprite(id - 1)}
+          />
+        </Link>
+      </div>
+      <div className="pokemon-name">
+        <p>#{id}</p>
+        <h3>{formatName(name)}</h3>
+      </div>
+      <div key={nextPokemonKey} ref={nextPokemonRef} className="pokemon-nav-option">
+        <Link to={`/pokemon/${id + 1}`}>
+          <img
+            onError={() => pokemonDoesNotExist(nextPokemonRef)}
+            src={getSprite(id + 1)}
+          />
+
+          <HiOutlineChevronRight />
+        </Link>
+      </div>
+    </div>
+  );
+};
+
+export default PokemonNav;

--- a/pokedex-react-flask-app/src/components/PokemonNav/PokemonNav.scss
+++ b/pokedex-react-flask-app/src/components/PokemonNav/PokemonNav.scss
@@ -1,0 +1,34 @@
+.pokemon-headers {
+    display: flex;
+    justify-content: space-around;
+    align-items: center;
+
+    .pokemon-nav-option {
+        min-width: 120px;
+    }
+  
+    div a {
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+  
+      svg {
+        font-size: 1.5em;
+        color: black;
+      }
+    }
+  
+    .pokemon-name {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+  
+      p {
+        margin: 0;
+      }
+  
+      h3 {
+        margin-top: 0.25rem;
+      }
+    }
+  }

--- a/pokedex-react-flask-app/src/components/TypeMoves/TypeMoves.jsx
+++ b/pokedex-react-flask-app/src/components/TypeMoves/TypeMoves.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 
 import { modifyMoves } from "../../helpers/modifyForTable";
 
@@ -10,12 +10,22 @@ import {
 
 import "./TypeMoves.scss";
 
-const TypeMoves = ({ list }) => {
+const TypeMoves = ({ list, generationId, onlySelectedGen }) => {
+  const filteredMoves = useMemo(() => {
+    if (generationId === "All") return list;
+    return list.filter((move) => {
+      const isWithinGen = move.generation_id <= generationId;
+      const isExactGen = move.generation_id === generationId;
+      return onlySelectedGen ? isExactGen : isWithinGen;
+    });
+  }, [list, generationId, onlySelectedGen]);
+
   const { tableData, columns } = modifyMoves({
-    moves: list.map((move) => ({ moveInfo: move })),
+    moves: filteredMoves.map((move) => ({ moveInfo: move })),
     KindImageComponent,
     NameComponent: MoveNameComponent,
     hasType: false,
+    hasGeneration: !onlySelectedGen,
   });
 
   return <Table data={tableData} columns={columns} />;

--- a/pokedex-react-flask-app/src/components/TypePokemon/TypePokemon.jsx
+++ b/pokedex-react-flask-app/src/components/TypePokemon/TypePokemon.jsx
@@ -16,6 +16,7 @@ import "./TypePokemon.scss";
 
 const TypePokemon = ({ name, list, typeId, generationId, onlySelectedGen }) => {
   const [byType, setbyType] = useState();
+  const [tableExtended, setTableExtended] = useState(false);
 
   const typeBarRefs = useRef(null);
   const secondaryTypeTableRefsList = useRef([]);
@@ -63,6 +64,7 @@ const TypePokemon = ({ name, list, typeId, generationId, onlySelectedGen }) => {
     NameComponent: PokemonNameComponent,
     hasType: false,
     hasGeneration: !onlySelectedGen,
+    hasStats: tableExtended,
   });
 
   const modifiedSemiData = Object.values(semi).map((group) => {
@@ -74,6 +76,7 @@ const TypePokemon = ({ name, list, typeId, generationId, onlySelectedGen }) => {
         TypesImageComponent,
         pageId: typeId,
         hasGeneration: !onlySelectedGen,
+        hasStats: tableExtended,
       }),
       name: group.type_name,
     };
@@ -81,6 +84,18 @@ const TypePokemon = ({ name, list, typeId, generationId, onlySelectedGen }) => {
 
   return (
     <div>
+      <div className="checkbox-input">
+        <label htmlFor="ExtendTable">
+          Show Stats
+          <input
+            id="ExtendTable"
+            type="checkbox"
+            className="clickable"
+            checked={tableExtended}
+            onChange={(e) => setTableExtended(e.target.checked)}
+          />
+        </label>
+      </div>
       <h4 className="pure-pokemon-table-header">
         Pure {formatName(name)} Pokemon
       </h4>

--- a/pokedex-react-flask-app/src/components/TypePokemon/TypePokemon.jsx
+++ b/pokedex-react-flask-app/src/components/TypePokemon/TypePokemon.jsx
@@ -14,7 +14,7 @@ import {
 
 import "./TypePokemon.scss";
 
-const TypePokemon = ({ name, list, typeId }) => {
+const TypePokemon = ({ name, list, typeId, generationId, onlySelectedGen }) => {
   const [byType, setbyType] = useState();
 
   const typeBarRefs = useRef(null);
@@ -27,9 +27,21 @@ const TypePokemon = ({ name, list, typeId }) => {
     setbyType(false);
   }, [typeId]);
 
+  const filteredPokemon = useMemo(() => {
+    if (generationId === "All") return list;
+    return list.filter((pokemon) => {
+      const gen =
+        pokemon.pokemon_v2_pokemon.pokemon_v2_pokemonforms[0]
+          .pokemon_v2_versiongroup.generation_id;
+      const isWithinGen = gen <= generationId;
+      const isExactGen = gen === generationId;
+      return onlySelectedGen ? isExactGen : isWithinGen;
+    });
+  }, [list, generationId, onlySelectedGen]);
+
   const sortedPokemonData = useMemo(
-    () => sortPokemonByTypes({ pokemons: list, id: typeId, byType }),
-    [list, byType]
+    () => sortPokemonByTypes({ pokemons: filteredPokemon, id: typeId, byType }),
+    [filteredPokemon, byType]
   );
   const { 0: pure, ...semi } = sortedPokemonData;
 
@@ -50,6 +62,7 @@ const TypePokemon = ({ name, list, typeId }) => {
     SpriteComponent,
     NameComponent: PokemonNameComponent,
     hasType: false,
+    hasGeneration: !onlySelectedGen,
   });
 
   const modifiedSemiData = Object.values(semi).map((group) => {
@@ -60,6 +73,7 @@ const TypePokemon = ({ name, list, typeId }) => {
         NameComponent: PokemonNameComponent,
         TypesImageComponent,
         pageId: typeId,
+        hasGeneration: !onlySelectedGen,
       }),
       name: group.type_name,
     };

--- a/pokedex-react-flask-app/src/components/TypePokemon/TypePokemon.scss
+++ b/pokedex-react-flask-app/src/components/TypePokemon/TypePokemon.scss
@@ -54,3 +54,7 @@
 .secondary-type-table {
   scroll-margin-top: 50px;
 }
+
+.checkbox-input {
+  margin-bottom: 1em;
+}

--- a/pokedex-react-flask-app/src/components/index.js
+++ b/pokedex-react-flask-app/src/components/index.js
@@ -13,6 +13,7 @@ export { default as NavBar } from "./NavBar/NavBar";
 export { default as PokemonCry } from "./PokemonCry/PokemonCry";
 export { default as PokemonImage } from "./PokemonImage/PokemonImage";
 export { default as PokemonList } from "./PokemonList/PokemonList";
+export { default as PokemonNav } from "./PokemonNav/PokemonNav";
 export { default as MovePokemonsTable } from "./PokemonsTable/MovePokemonsTable/MovePokemonsTable";
 export { default as AbilityPokemonsTable } from "./PokemonsTable/AbilityPokemonsTable/AbilityPokemonsTable";
 export { default as ShinyCounter } from "./ShinyCounter/ShinyCounter";

--- a/pokedex-react-flask-app/src/helpers/modifyForTable.js
+++ b/pokedex-react-flask-app/src/helpers/modifyForTable.js
@@ -8,6 +8,7 @@ function modifyMoves({
   hasTms = false,
   hasPopUpText = false,
   hasType = true,
+  hasGeneration = false,
   TypeImageComponent,
   KindImageComponent,
   NameComponent,
@@ -32,6 +33,9 @@ function modifyMoves({
   }
   if (hasTms) {
     columns.unshift({ Header: "TM", accessor: "tm" });
+  }
+  if (hasGeneration) {
+    columns.unshift({ Header: "Gen", accessor: "gen" });
   }
   const tableData = moves.map((move, i) => {
     const hasFlavourText = hasPopUpText && move.moveInfo.flavourText.length > 0;
@@ -58,6 +62,9 @@ function modifyMoves({
         ...modifiedMove,
       };
     }
+    if (hasGeneration) {
+      return { gen: move.moveInfo.generation_id, ...modifiedMove };
+    }
     return modifiedMove;
   });
   return { columns, tableData };
@@ -69,6 +76,7 @@ function modifyPokemon({
   hasItemRarityData = false,
   hasAbilities = false,
   hasType = true,
+  hasGeneration = false,
   SpriteComponent,
   NameComponent,
   TypesImageComponent,
@@ -116,6 +124,9 @@ function modifyPokemon({
       }
     );
   }
+  if (hasGeneration) {
+    columns.splice(1, 0, { Header: "Gen", accessor: "gen" });
+  }
   const tableData = pokemons.map((pokemon, i) => {
     const pokemonData = pokemon.pokemon_v2_pokemon;
     const modifiedPokemon = {
@@ -145,7 +156,13 @@ function modifyPokemon({
         ?.pokemon_v2_ability || { name: "None" };
       return { ...modifiedPokemon, ...modifiedAbilities };
     }
-
+    if (hasGeneration) {
+      return {
+        ...modifiedPokemon,
+        gen: pokemonData.pokemon_v2_pokemonforms[0].pokemon_v2_versiongroup
+          .generation_id,
+      };
+    }
     return modifiedPokemon;
   });
   return { columns, tableData };

--- a/pokedex-react-flask-app/src/pages/AbilityDetail/AbilityDetail.scss
+++ b/pokedex-react-flask-app/src/pages/AbilityDetail/AbilityDetail.scss
@@ -1,3 +1,9 @@
 .app__ability-info {
-    text-align: center;
+  text-align: center;
+  width: 80%;
+  margin: 0 auto;
+
+  @media screen and (max-width: 700px) {
+    width: 100%;
+  }
 }

--- a/pokedex-react-flask-app/src/pages/EggGroupDetail/EggGroupDetail.jsx
+++ b/pokedex-react-flask-app/src/pages/EggGroupDetail/EggGroupDetail.jsx
@@ -54,21 +54,6 @@ const EggGroupDetail = () => {
         <h1>{formatName(eggGroupName)} Egg Group</h1>
       </div>
       <div className="app__egg-group-table-container">
-        {selectedGenerationId && selectedGenerationId !== "All" ? (
-          <div className="checkbox-input">
-            <label htmlFor="ShowOnlySelectedGenResults">
-              Only Generation {selectedGenerationId}
-              <input
-                type="checkbox"
-                id="ShowOnlySelectedGenResults"
-                checked={showOnlySelectedGenResults}
-                onChange={(e) =>
-                  setShowOnlySelectedGenResults(e.target.checked)
-                }
-              />
-            </label>
-          </div>
-        ) : null}
         <div className="select-input">
           <label htmlFor="GenerationSelector">Generation:</label>
           <select
@@ -83,6 +68,22 @@ const EggGroupDetail = () => {
             {generationOptions}
           </select>
         </div>
+        {selectedGenerationId && selectedGenerationId !== "All" ? (
+          <div className="checkbox-input">
+            <label htmlFor="ShowOnlySelectedGenResults">
+              Only Generation {selectedGenerationId}
+              <input
+                id="ShowOnlySelectedGenResults"
+                type="checkbox"
+                className="clickable"
+                checked={showOnlySelectedGenResults}
+                onChange={(e) =>
+                  setShowOnlySelectedGenResults(e.target.checked)
+                }
+              />
+            </label>
+          </div>
+        ) : null}
         <EggGroupPokemon
           name={eggGroupName}
           list={pokemons}

--- a/pokedex-react-flask-app/src/pages/EggGroupDetail/EggGroupDetail.jsx
+++ b/pokedex-react-flask-app/src/pages/EggGroupDetail/EggGroupDetail.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState, useMemo } from "react";
 import { useParams } from "react-router-dom";
 import { useQuery } from "@apollo/client";
 
@@ -14,12 +14,35 @@ import "./EggGroupDetail.scss";
 
 const EggGroupDetail = () => {
   const params = useParams();
+  const [selectedGenerationId, setSelectedGenerationId] = useState(null);
+  const [showOnlySelectedGenResults, setShowOnlySelectedGenResults] =
+    useState(false);
+
   const { data, loading } = useQuery(GET_EGG_GROUP_INFO, {
     variables: { id: parseInt(params.eggGroupId) },
     client: pokemonAPIClient,
   });
+
   useEffect(() => {
     window.scrollTo(0, 0);
+    setSelectedGenerationId("All");
+    setShowOnlySelectedGenResults(false);
+  }, [data]);
+
+  const generationOptions = useMemo(() => {
+    const options = [
+      <option key="all" value="All">
+        All
+      </option>,
+    ];
+    for (let i = 1; i <= 9; i++) {
+      options.push(
+        <option key={i} value={i}>
+          {i}
+        </option>
+      );
+    }
+    return options;
   }, [data]);
 
   if (loading) return <Loading />;
@@ -31,7 +54,42 @@ const EggGroupDetail = () => {
         <h1>{formatName(eggGroupName)} Egg Group</h1>
       </div>
       <div className="app__egg-group-table-container">
-        <EggGroupPokemon name={eggGroupName} list={pokemons} eggGroupId={id} />
+        {selectedGenerationId && selectedGenerationId !== "All" ? (
+          <div className="checkbox-input">
+            <label htmlFor="ShowOnlySelectedGenResults">
+              Only Generation {selectedGenerationId}
+              <input
+                type="checkbox"
+                id="ShowOnlySelectedGenResults"
+                checked={showOnlySelectedGenResults}
+                onChange={(e) =>
+                  setShowOnlySelectedGenResults(e.target.checked)
+                }
+              />
+            </label>
+          </div>
+        ) : null}
+        <div className="select-input">
+          <label htmlFor="GenerationSelector">Generation:</label>
+          <select
+            id="GenerationSelector"
+            value={selectedGenerationId || "All"}
+            onChange={(e) =>
+              setSelectedGenerationId(
+                e.target.value === "All" ? "All" : parseInt(e.target.value)
+              )
+            }
+          >
+            {generationOptions}
+          </select>
+        </div>
+        <EggGroupPokemon
+          name={eggGroupName}
+          list={pokemons}
+          eggGroupId={id}
+          generationId={selectedGenerationId}
+          onlySelectedGen={showOnlySelectedGenResults}
+        />
       </div>
     </div>
   );

--- a/pokedex-react-flask-app/src/pages/EggGroupDetail/EggGroupDetail.scss
+++ b/pokedex-react-flask-app/src/pages/EggGroupDetail/EggGroupDetail.scss
@@ -7,10 +7,6 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-
-  h1 {
-    margin-bottom: 0;
-  }
 }
 
 .app__egg-group-details-tabs-container {

--- a/pokedex-react-flask-app/src/pages/PokemonDetail/PokemonDetail.jsx
+++ b/pokedex-react-flask-app/src/pages/PokemonDetail/PokemonDetail.jsx
@@ -1,8 +1,7 @@
 import React, { useEffect, useMemo } from "react";
-import { useParams, Link } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import { useNavigate } from "react-router-dom";
 import { useQuery, useMutation } from "@apollo/client";
-import { HiOutlineChevronLeft, HiOutlineChevronRight } from "react-icons/hi";
 
 import { GET_POKEMON_INFO } from "../../api/queries/pokeapi";
 import {
@@ -17,6 +16,7 @@ import {
   TypeEffectiveness,
   PokemonCry,
   PokemonImage,
+  PokemonNav,
   StatChart,
   Abilities,
   MovesTable,
@@ -33,8 +33,7 @@ import {
 
 import { formatName } from "../../helpers/format";
 import { eggGroupNameHelper } from "../../helpers/eggGroupNamehelper";
-import { getSprite } from "../../helpers/pictures";
-import { handleSpriteError } from "../../helpers/error";
+
 import { convertStats, getEvYield } from "../../helpers/statModifier";
 import { calculateCatchPercent } from "../../helpers/calculateCatchPercent";
 
@@ -132,31 +131,7 @@ const PokemonDetail = () => {
       }`}
     >
       <div className="app-pokemon-detail-info">
-        <div className="pokemon-headers">
-          <div className={pokemonIdInt <= 1 ? "hide" : ""}>
-            <Link to={`/pokemon/${pokemonIdInt - 1}`}>
-              <HiOutlineChevronLeft />
-              <img
-                onError={handleSpriteError}
-                src={getSprite(pokemonIdInt - 1)}
-              />
-            </Link>
-          </div>
-          <div className="pokemon-name">
-            <p>#{params.pokemonId}</p>
-            <h3>{formatName(name)}</h3>
-          </div>
-          <div>
-            <Link to={`/pokemon/${pokemonIdInt + 1}`}>
-              <img
-                onError={handleSpriteError}
-                src={getSprite(pokemonIdInt + 1)}
-              />
-
-              <HiOutlineChevronRight />
-            </Link>
-          </div>
-        </div>
+        <PokemonNav name={name} id ={pokemonIdInt} />
         <GenerationSelector
           generation={generation}
           pokedexes={info.pokedexes}

--- a/pokedex-react-flask-app/src/pages/PokemonDetail/PokemonDetail.scss
+++ b/pokedex-react-flask-app/src/pages/PokemonDetail/PokemonDetail.scss
@@ -36,37 +36,6 @@
   }
 }
 
-.pokemon-headers {
-  display: flex;
-  justify-content: space-around;
-  align-items: center;
-
-  div a {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-
-    svg {
-      font-size: 1.5em;
-      color: black;
-    }
-  }
-
-  .pokemon-name {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-
-    p {
-      margin: 0;
-    }
-
-    h3 {
-      margin-top: 0.25rem;
-    }
-  }
-}
-
 .favourite-button {
   display: block;
   margin: 1em auto;

--- a/pokedex-react-flask-app/src/pages/TeamEdit/TeamEdit.jsx
+++ b/pokedex-react-flask-app/src/pages/TeamEdit/TeamEdit.jsx
@@ -21,6 +21,8 @@ import { Loading, TeamPokemonEdit } from "../../components";
 
 import { getSprite } from "../../helpers/pictures";
 import { exportTeam } from "../../helpers/exportTeam";
+import { handleSpriteError } from "../../helpers/error";
+
 import {
   convertStats,
   calculateTeamPokemonStats,
@@ -357,6 +359,7 @@ const TeamEdit = () => {
           <img
             src={getSprite(tab.pokemon?.pokemonId)}
             alt={tab.pokemon?.name}
+            onError={handleSpriteError}
           />
         </Tab>
       ),

--- a/pokedex-react-flask-app/src/pages/TypeDetail/TypeDetail.jsx
+++ b/pokedex-react-flask-app/src/pages/TypeDetail/TypeDetail.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useMemo } from "react";
 import { useParams } from "react-router-dom";
 import { useQuery } from "@apollo/client";
 
@@ -21,17 +21,46 @@ import "./TypeDetail.scss";
 const TypeDetail = () => {
   const params = useParams();
   const [selectedTab, setSelectedTab] = useState(tabs[0]);
+  const [generationId, setGenerationId] = useState(null);
+  const [selectedGenerationId, setSelectedGenerationId] = useState(null);
+  const [showOnlySelectedGenResults, setShowOnlySelectedGenResults] =
+    useState(false);
 
   const { data, loading } = useQuery(GET_TYPE_INFO, {
     variables: { id: parseInt(params.typeId) },
     client: pokemonAPIClient,
+    onCompleted: (data) => {
+      setGenerationId(data.pokemon_v2_type[0].generation_id);
+    },
   });
+
   useEffect(() => {
     window.scrollTo(0, 0);
+    setSelectedGenerationId("All")
+    setShowOnlySelectedGenResults(false)
   }, [data]);
+  
+
+  const generationOptions = useMemo(() => {
+    if (!generationId) return []; // Handle undefined or missing generation_id
+    const options = [
+      <option key="all" value="All">
+        All
+      </option>,
+    ];
+    for (let i = generationId; i <= 9; i++) {
+      options.push(
+        <option key={i} value={i}>
+          {i}
+        </option>
+      );
+    }
+    return options;
+  }, [generationId, data]);
 
   if (loading) return <Loading />;
   const { name, moves, pokemons, id } = data.pokemon_v2_type[0];
+
   return (
     <div className={`app__type-details ${name}-color-2`}>
       <div className="app__type-details-info">
@@ -54,10 +83,51 @@ const TypeDetail = () => {
         </div>
       </div>
       <div className="app__type-table-container">
+        {selectedGenerationId && selectedGenerationId !== "All" ? (
+          <div className="checkbox-input">
+            <label htmlFor="ShowOnlySelectedGenResults">
+              Only Generation {selectedGenerationId}
+              <input
+                type="checkbox"
+                id="ShowOnlySelectedGenResults"
+                checked={showOnlySelectedGenResults}
+                onChange={(e) =>
+                  setShowOnlySelectedGenResults(e.target.checked)
+                }
+              />
+            </label>
+          </div>
+        ) : null}
+        <div className="select-input">
+          <label htmlFor="GenerationSelector">Generation:</label>
+          <select
+            id="GenerationSelector"
+            value={selectedGenerationId || "All"}
+            onChange={(e) =>
+              setSelectedGenerationId(
+                e.target.value === "All" ? "All" : parseInt(e.target.value)
+              )
+            }
+          >
+            {generationOptions}
+          </select>
+        </div>
         {selectedTab === "Pokemon" && (
-          <TypePokemon name={name} list={pokemons} typeId={id} />
+          <TypePokemon
+            name={name}
+            list={pokemons}
+            typeId={id}
+            generationId={selectedGenerationId}
+            onlySelectedGen={showOnlySelectedGenResults}
+          />
         )}
-        {selectedTab === "Moves" && <TypeMoves list={moves} />}
+        {selectedTab === "Moves" && (
+          <TypeMoves
+            list={moves}
+            generationId={selectedGenerationId}
+            onlySelectedGen={showOnlySelectedGenResults}
+          />
+        )}
       </div>
     </div>
   );

--- a/pokedex-react-flask-app/src/pages/TypeDetail/TypeDetail.jsx
+++ b/pokedex-react-flask-app/src/pages/TypeDetail/TypeDetail.jsx
@@ -36,13 +36,12 @@ const TypeDetail = () => {
 
   useEffect(() => {
     window.scrollTo(0, 0);
-    setSelectedGenerationId("All")
-    setShowOnlySelectedGenResults(false)
+    setSelectedGenerationId("All");
+    setShowOnlySelectedGenResults(false);
   }, [data]);
-  
 
   const generationOptions = useMemo(() => {
-    if (!generationId) return []; // Handle undefined or missing generation_id
+    if (!generationId) return [];
     const options = [
       <option key="all" value="All">
         All
@@ -83,21 +82,6 @@ const TypeDetail = () => {
         </div>
       </div>
       <div className="app__type-table-container">
-        {selectedGenerationId && selectedGenerationId !== "All" ? (
-          <div className="checkbox-input">
-            <label htmlFor="ShowOnlySelectedGenResults">
-              Only Generation {selectedGenerationId}
-              <input
-                type="checkbox"
-                id="ShowOnlySelectedGenResults"
-                checked={showOnlySelectedGenResults}
-                onChange={(e) =>
-                  setShowOnlySelectedGenResults(e.target.checked)
-                }
-              />
-            </label>
-          </div>
-        ) : null}
         <div className="select-input">
           <label htmlFor="GenerationSelector">Generation:</label>
           <select
@@ -112,6 +96,22 @@ const TypeDetail = () => {
             {generationOptions}
           </select>
         </div>
+        {selectedGenerationId && selectedGenerationId !== "All" ? (
+          <div className="checkbox-input">
+            <label htmlFor="ShowOnlySelectedGenResults">
+              Only Generation {selectedGenerationId}
+              <input
+                id="ShowOnlySelectedGenResults"
+                type="checkbox"
+                className="clickable"
+                checked={showOnlySelectedGenResults}
+                onChange={(e) =>
+                  setShowOnlySelectedGenResults(e.target.checked)
+                }
+              />
+            </label>
+          </div>
+        ) : null}
         {selectedTab === "Pokemon" && (
           <TypePokemon
             name={name}


### PR DESCRIPTION
Includes:
Generation Selector Based on introduction Of Type/Egg group
Includes checkbox to filter based on Only that generation or previous ones as well
Add Stats to Table with checkbox to Extend to show with ordering

Fixes:
Pokemon Cry only on Desktop as doesn't work on Mobil

Change:
Extracted Nav to its own component on Pokemon Details Page